### PR TITLE
added support for y12 and tfi export

### DIFF
--- a/tfi_file.c
+++ b/tfi_file.c
@@ -109,18 +109,21 @@ static int load(void *data, int data_len, struct fm_voice_bank  *bank) {
 static int save(struct fm_voice_bank *bank, struct fm_voice_bank_position *pos, int (*write_fn)(void *, size_t, void *), void *data_ptr) {
 	if(bank->num_opn_voices <= pos->opn) return -1;	
 	struct tfi_file f;
-	f.fb = bank->opn_voices[pos->opn].fb_con >> 3;
-	f.alg = bank->opn_voices[pos->opn].fb_con & 0x07;
+	tfi_file_init(&f);
+	opn_voice* voice = &bank->opn_voices[pos->opn];
+	if (!voice) return - 1;
+	f.fb = opn_voice_get_fb(voice);
+	f.alg = opn_voice_get_con(voice);
 	for(int i = 0; i < 4; i++) {
-		f.operators[i].dt = bank->opn_voices[pos->opn].operators[i].dt_mul >> 3;
-		f.operators[i].mul = bank->opn_voices[pos->opn].operators[i].dt_mul & 0x07;
-		f.operators[i].tl = opn_voice_get_operator_tl(bank->opn_voices + pos->opn, i);
-		f.operators[i].rs = bank->opn_voices[pos->opn].operators[i].ks_ar >> 6;
-		f.operators[i].ar = bank->opn_voices[pos->opn].operators[i].ks_ar & 0x1f;
-		f.operators[i].dr = bank->opn_voices[pos->opn].operators[i].am_dr;
-		f.operators[i].sr = opn_voice_get_operator_sr(bank->opn_voices + pos->opn, i);
-		f.operators[i].sl = bank->opn_voices[pos->opn].operators[i].sl_rr >> 4;
-		f.operators[i].rr = bank->opn_voices[pos->opn].operators[i].sl_rr & 0x0f;
+		f.operators[i].dt = opn_voice_get_operator_dt(voice, i);
+		f.operators[i].mul = opn_voice_get_operator_mul(voice, i);
+		f.operators[i].tl = opn_voice_get_operator_tl(voice, i);
+		f.operators[i].rs = opn_voice_get_operator_ks(voice, i);
+		f.operators[i].ar = opn_voice_get_operator_ar(voice, i);
+		f.operators[i].dr = opn_voice_get_operator_dr(voice, i);
+		f.operators[i].sr = opn_voice_get_operator_sr(voice, i);
+		f.operators[i].sl = opn_voice_get_operator_sl(voice, i);
+		f.operators[i].rr = opn_voice_get_operator_rr(voice, i);
 	}
 	pos->opn++;
 	return tfi_file_save(&f, write_fn, data_ptr);

--- a/tfi_file.c
+++ b/tfi_file.c
@@ -21,6 +21,19 @@ $0C...		ssg
 }
 */
 
+// get signed DT from unsigned DT
+static int convert_dt_u2s(int dt_unsigned) {
+	int dt_signed = dt_unsigned & 3;
+	if (dt_unsigned & 4) return -dt_signed;
+	else return dt_signed;
+}
+
+// get unsigned DT from signed DT
+static int convert_dt_s2u(int dt_signed) {
+	if (dt_signed < 0) return ((-dt_signed) & 3) | 4;
+	else return dt_signed & 3;
+}
+
 void tfi_file_init(struct tfi_file *f) {
 	memset(f, 0, sizeof(*f));
 }
@@ -35,7 +48,7 @@ int tfi_file_load(struct tfi_file *tfi, uint8_t *data, size_t data_len) {
 
 	for(int i = 0; i < 4; i++) {
 		tfi->operators[i].mul = *p++;
-		tfi->operators[i].dt = *p++;
+		tfi->operators[i].dt = convert_dt_s2u((*p++ & 7) - 3);
 		tfi->operators[i].tl = *p++;
 		tfi->operators[i].rs = *p++;
 		tfi->operators[i].ar = *p++;
@@ -51,20 +64,20 @@ int tfi_file_load(struct tfi_file *tfi, uint8_t *data, size_t data_len) {
 
 int tfi_file_save(struct tfi_file *f, int (*write_fn)(void *, size_t, void *), void *data_ptr) {
 	uint8_t buf[42] = { 0 };
-	int bc = 0;
-	buf[bc++] = f->alg;
-	buf[bc++] = f->fb;
+	uint8_t *p = buf;
+	*p++ = f->alg;
+	*p++ = f->fb;
 	for(int i = 0; i < 4; i++) {
-		buf[bc++] = f->operators[i].mul;
-		buf[bc++] = f->operators[i].dt;
-		buf[bc++] = f->operators[i].tl;
-		buf[bc++] = f->operators[i].rs;
-		buf[bc++] = f->operators[i].ar;
-		buf[bc++] = f->operators[i].dr;
-		buf[bc++] = f->operators[i].sr;
-		buf[bc++] = f->operators[i].rr;
-		buf[bc++] = f->operators[i].sl;
-		buf[bc++] = f->operators[i].ssg_eg;
+		*p++ = f->operators[i].mul;
+		*p++ = 3 + convert_dt_u2s(f->operators[i].dt);
+		*p++ = f->operators[i].tl;
+		*p++ = f->operators[i].rs;
+		*p++ = f->operators[i].ar;
+		*p++ = f->operators[i].dr;
+		*p++ = f->operators[i].sr;
+		*p++ = f->operators[i].rr;
+		*p++ = f->operators[i].sl;
+		*p++ = f->operators[i].ssg_eg;
 	}
 	return write_fn(buf, 42, data_ptr);
 }

--- a/tfi_file.c
+++ b/tfi_file.c
@@ -110,7 +110,7 @@ static int save(struct fm_voice_bank *bank, struct fm_voice_bank_position *pos, 
 	if(bank->num_opn_voices <= pos->opn) return -1;	
 	struct tfi_file f;
 	tfi_file_init(&f);
-	opn_voice* voice = &bank->opn_voices[pos->opn];
+	struct opn_voice* voice = &bank->opn_voices[pos->opn];
 	if (!voice) return - 1;
 	f.fb = opn_voice_get_fb(voice);
 	f.alg = opn_voice_get_con(voice);

--- a/y12_file.c
+++ b/y12_file.c
@@ -135,7 +135,7 @@ static int save(struct fm_voice_bank *bank, struct fm_voice_bank_position *pos, 
 	if(bank->num_opn_voices <= pos->opn) return -1;
 	struct y12_file f;
 	y12_file_init(&f);
-	opn_voice* voice = &bank->opn_voices[pos->opn];
+	struct opn_voice* voice = &bank->opn_voices[pos->opn];
 	if (!voice) return -1;
 	memcpy(f.name, voice->name, 15);
 	memcpy(f.dumper, voice->dumper, 15);

--- a/y12_file.c
+++ b/y12_file.c
@@ -134,21 +134,24 @@ static int load(void *data, int data_len, struct fm_voice_bank  *bank) {
 static int save(struct fm_voice_bank *bank, struct fm_voice_bank_position *pos, int (*write_fn)(void *, size_t, void *), void *data_ptr) {
 	if(bank->num_opn_voices <= pos->opn) return -1;
 	struct y12_file f;
-	strcpy(f.name, bank->opn_voices[pos->opn].name);
-	strcpy(f.dumper, bank->opn_voices[pos->opn].dumper);
-	strcpy(f.game, bank->opn_voices[pos->opn].game);
-	f.name_len = strlen(bank->opn_voices[pos->opn].name);
-	f.dumper_len = strlen(bank->opn_voices[pos->opn].dumper);
-	f.game_len = strlen(bank->opn_voices[pos->opn].game);
-	f.fb = bank->opn_voices[pos->opn].fb_con >> 3;
-	f.alg = bank->opn_voices[pos->opn].fb_con & 0x07;
+	y12_file_init(&f);
+	opn_voice* voice = &bank->opn_voices[pos->opn];
+	if (!voice) return -1;
+	memcpy(f.name, voice->name, 15);
+	memcpy(f.dumper, voice->dumper, 15);
+	memcpy(f.game, voice->game, 15);
+	f.name_len = strlen(f.name);
+	f.dumper_len = strlen(f.dumper);
+	f.game_len = strlen(f.game);
+	f.fb = opn_voice_get_fb(voice);
+	f.alg = opn_voice_get_con(voice);
 	for(int i = 0; i < 4; i++) {
-		f.operators[i].mul_dt = bank->opn_voices[pos->opn].operators[i].dt_mul;
+		f.operators[i].mul_dt = voice->operators[i].dt_mul;
 		f.operators[i].tl = opn_voice_get_operator_tl(bank->opn_voices + pos->opn, i);
-		f.operators[i].ar_rs = bank->opn_voices[pos->opn].operators[i].ks_ar;
-		f.operators[i].dr_am = bank->opn_voices[pos->opn].operators[i].am_dr;
+		f.operators[i].ar_rs = voice->operators[i].ks_ar;
+		f.operators[i].dr_am = voice->operators[i].am_dr;
 		f.operators[i].sr = opn_voice_get_operator_sr(bank->opn_voices + pos->opn, i);
-		f.operators[i].rr_sl = bank->opn_voices[pos->opn].operators[i].sl_rr;
+		f.operators[i].rr_sl = voice->operators[i].sl_rr;
 	}
 	pos->opn++;
 	return y12_file_save(&f, write_fn, data_ptr);

--- a/y12_file.c
+++ b/y12_file.c
@@ -57,7 +57,6 @@ int y12_file_save(struct y12_file *f, int (*write_fn)(void *, size_t, void *), v
 	memcpy(p, f->dumper, 16);
 	p += 16;
 	memcpy(p, f->game, 16);
-	bc += 16;
 	return write_fn(buf, 128, data_ptr);
 }
 

--- a/y12_file.c
+++ b/y12_file.c
@@ -38,25 +38,25 @@ int y12_file_load(struct y12_file *f, uint8_t *data, size_t data_len) {
 
 int y12_file_save(struct y12_file *f, int (*write_fn)(void *, size_t, void *), void *data_ptr) {
 	uint8_t buf[128] = { 0 };
-	int bc = 0;
+	uint8_t* p = buf;
 	for(int i = 0; i < 4; i++) {
-		buf[bc++] = f->operators[i].mul_dt;
-		buf[bc++] = f->operators[i].tl;
-		buf[bc++] = f->operators[i].ar_rs;
-		buf[bc++] = f->operators[i].dr_am;
-		buf[bc++] = f->operators[i].sr;
-		buf[bc++] = f->operators[i].rr_sl;
-		buf[bc++] = f->operators[i].ssg;
-		bc += 9;
+		*p++ = f->operators[i].mul_dt;
+		*p++ = f->operators[i].tl;
+		*p++ = f->operators[i].ar_rs;
+		*p++ = f->operators[i].dr_am;
+		*p++ = f->operators[i].sr;
+		*p++ = f->operators[i].rr_sl;
+		*p++ = f->operators[i].ssg;
+		p += 9;
 	}
-	buf[bc++] = f->alg;
-	buf[bc++] = f->fb;
-	bc += 14;
-	memcpy(&buf[bc], f->name, 16);
-	bc += 16;
-	memcpy(&buf[bc], f->dumper, 16);
-	bc += 16;
-	memcpy(&buf[bc], f->game, 16);
+	*p++ = f->alg;
+	*p++ = f->fb;
+	p += 14;
+	memcpy(p, f->name, 16);
+	p += 16;
+	memcpy(p, f->dumper, 16);
+	p += 16;
+	memcpy(p, f->game, 16);
 	bc += 16;
 	return write_fn(buf, 128, data_ptr);
 }


### PR DESCRIPTION
Also y12 struct had max_opm_voices = 1 and max_opn_voices = 0, it should probably be the other way round as y12 is an instrument format for YM2612/OPN2, right?