### PR TITLE
opm_file.c: Fix format hardening

### DIFF
--- a/opm_file.c
+++ b/opm_file.c
@@ -398,7 +398,7 @@ static int save(struct fm_voice_bank *bank, struct fm_voice_bank_position *pos, 
 		struct opm_file_voice fv;
 		memset(&fv, 0, sizeof(fv));
 		fv.number = i;
-		if(v->name && strlen(v->name) > 0) snprintf(fv.name, sizeof(fv.name), v->name);
+		if(v->name && strlen(v->name) > 0) snprintf(fv.name, sizeof(fv.name), "%s", v->name);
 		else snprintf(fv.name, sizeof(fv.name), "Instrument %d", i);
 		fv.lfo_lfrq = v->lfrq;
 		fv.lfo_amd = v->amd;


### PR DESCRIPTION
```
opm_file.c:401:88: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
  401 |                 if(v->name && strlen(v->name) > 0) snprintf(fv.name, sizeof(fv.name), v->name);
      |                                                                                       ~^~~~~~
```